### PR TITLE
Fixed 2 issues of type: PYTHON_E225 throughout 1 file in repo.

### DIFF
--- a/gdax_book.py
+++ b/gdax_book.py
@@ -9,7 +9,7 @@ from gdax.websocket_client import WebsocketClient
 class GDaxBook(WebsocketClient):
     def __init__(self, product_id='BTC-USD'):
         print("Initializing order Book websocket for " + product_id)
-        self.product=product_id
+        self.product = product_id
         super(GDaxBook, self).__init__(products=[self.product])
         super(GDaxBook, self).start()
         self._asks = RBTree()
@@ -225,7 +225,7 @@ if __name__ == '__main__':
     import time
     wsClient = WebsocketClient()
     wsClient.start()
-    wsClient.products=["ETH-USD", "ETH-BTC", "BTC-USD", "LTC-USD", "LTC-BTC", "ETH-EUR", "BTC-EUR", "LTC-EUR"]
+    wsClient.products = ["ETH-USD", "ETH-BTC", "BTC-USD", "LTC-USD", "LTC-BTC", "ETH-EUR", "BTC-EUR", "LTC-EUR"]
     order_book = OrderBook("ETH-USD")
     order_book.start()
     time.sleep(20)


### PR DESCRIPTION
PYTHON_E225: 'Fix extraneous whitespace around keywords.'.  This is a pep8 error code.          See <a href='https://pep8.readthedocs.io/en/latest/intro.html#error-codes'>        here for a complete list of error codes</a>.

It was fixed with <a href='https://github.com/hhatto/autopep8'>autopep8</a>.  The fix is completely safe.